### PR TITLE
fix: use Bitnami legacy PostgreSQL image

### DIFF
--- a/charts/gvm-lite-stack/values.yaml
+++ b/charts/gvm-lite-stack/values.yaml
@@ -96,9 +96,16 @@ redis:
     hz 10
     aof-rewrite-incremental-fsync yes
 # --- Postgres subchart (optional) ---
+global:
+  security:
+    allowInsecureImages: true
 postgresql:
   enabled: true
   architecture: standalone
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 17.6.0-debian-12-r4
   auth:
     username: "gvmd" # app user
     password: "gvmdpw" # or leave empty to auto-generate


### PR DESCRIPTION
Switch the PostgreSQL dependency image to bitnamilegacy/postgresql because the previously rendered Bitnami PostgreSQL image tags were no longer available on Docker Hub.

Enable global.security.allowInsecureImages for the Bitnami chart so Helm can render and deploy the legacy image repository.