### PR TITLE
add: mount Notus feed and add gvmd-lite env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,26 @@ Helm chart that deploys a lightweight Greenbone stack on Kubernetes:
 
 ### Required
 
-- **Helm** (v3.x)
-    - Verify: `helm version`
-- **helm-unittest** plugin (for unit tests)
-    - Install: `helm plugin install https://github.com/helm-unittest/helm-unittest`
-    - Verify: `helm plugin list | grep unittest`
+* **Helm** (v3.x)
+
+    * Verify: `helm version`
+* **helm-unittest** plugin (for unit tests)
+
+    * Install: `helm plugin install https://github.com/helm-unittest/helm-unittest`
+    * Verify: `helm plugin list | grep unittest`
 
 ### Recommended
 
-- **kubeconform** (validates rendered manifests against Kubernetes schemas)
-    - macOS (Homebrew): `brew install kubeconform`
-    - Linux: install from GitHub releases (see CI workflow)
-    - Verify: `kubeconform -v`
-- **yamlfmt** (formats / checks YAML style)
-    - Install (Go): `go install github.com/google/yamlfmt/cmd/yamlfmt@latest`
-    - Ensure it’s on PATH: `export PATH="$PATH:$HOME/go/bin"`
-    - Verify: `yamlfmt -version` (or `yamlfmt --version`)
+* **kubeconform** (validates rendered manifests against Kubernetes schemas)
+
+    * macOS (Homebrew): `brew install kubeconform`
+    * Linux: install from GitHub releases (see CI workflow)
+    * Verify: `kubeconform -v`
+* **yamlfmt** (formats / checks YAML style)
+
+    * Install (Go): `go install github.com/google/yamlfmt/cmd/yamlfmt@latest`
+    * Ensure it’s on PATH: `export PATH="$PATH:$HOME/go/bin"`
+    * Verify: `yamlfmt -version` or `yamlfmt --version`
 
 > Note: Helm templates under `charts/**/templates/` are **not valid YAML** until rendered, so formatting is applied only
 > to `Chart.yaml`, `values*.yaml`, and `tests/**/*.yaml`.
@@ -43,49 +47,57 @@ This repository uses a Makefile to keep common actions consistent locally and in
 
 > Chart location: `charts/gvm-lite-stack`
 
-### Format (non-template YAML only)
+### Format non-template YAML only
 
-- Format files in-place:
-    - `make fmt`
-- Check formatting (CI-style; fails if formatting would change):
-    - `make fmt-check`
+* Format files in-place:
+
+    * `make fmt`
+* Check formatting CI-style, fails if formatting would change:
+
+    * `make fmt-check`
 
 ### Lint
 
-- Run Helm lint:
-    - `make lint`
+* Run Helm lint:
+
+    * `make lint`
 
 ### Unit tests
 
-- Run Helm unit tests:
-    - `make test`
+* Run Helm unit tests:
+
+    * `make test`
 
 ### Render manifests
 
-- Render the chart to a local file:
-    - `make render`
-    - Output: `/tmp/gvm-lite-stack.rendered.yaml`
+* Render the chart to a local file:
 
-### Schema validation (rendered output)
+    * `make render`
+    * Output: `/tmp/gvm-lite-stack.rendered.yaml`
 
-- Validate rendered manifests with kubeconform:
-    - `make validate`
+### Schema validation rendered output
 
-### Coverage gate (Helm template coverage)
+* Validate rendered manifests with kubeconform:
 
-- Ensure every template has at least one unit test referencing it:
-    - `make coverage`
+    * `make validate`
 
-### Full local check (recommended before pushing)
+### Coverage gate Helm template coverage
 
-- Run everything CI expects:
-    - `make check`
+* Ensure every template has at least one unit test referencing it:
+
+    * `make coverage`
+
+### Full local check recommended before pushing
+
+* Run everything CI expects:
+
+    * `make check`
 
 ---
 
 ## Chart tree
 
-```
+```text
 charts/
   gvm-lite-stack/
     Chart.yaml
@@ -106,13 +118,19 @@ helm dependency build
 
 ---
 
-## Render manifests (no deploy)
+## Render manifests no deploy
 
 ```bash
 helm template gvm ../gvm-lite-stack -n gvm > gvm-lite-stack.yaml
-# or from repo root
+```
+
+Or from the repository root:
+
+```bash
 helm template gvm charts/gvm-lite-stack -n gvm > gvm-lite-stack.yaml
 ```
+
+Render with explicit values:
 
 ```bash
 helm template gvm charts/gvm-lite-stack -n gvm \
@@ -121,7 +139,7 @@ helm template gvm charts/gvm-lite-stack -n gvm \
 
 ---
 
-## Deploy (default values.yaml)
+## Deploy default values.yaml
 
 ```bash
 helm install gvm charts/gvm-lite-stack -n gvm --create-namespace \
@@ -152,14 +170,14 @@ kubectl get svc -n gvm
 
 Service endpoints inside the cluster:
 
-* Frontend (NodePort): **gsa-lite** to node port **30080**
+* Frontend NodePort: **gsa-lite** to node port **30080**
 * API service: `gvmd-lite.gvm.svc.cluster.local:8082`
 * Report-render service: `gvmr-lite.gvm.svc.cluster.local:8084`
 * Scanner service: `openvas-service.gvm.svc.cluster.local:3001`
 
 ---
 
-## Development loop with local images (Minikube)
+## Development loop with local images Minikube
 
 Build images **inside** Minikube and point the chart at those tags:
 
@@ -168,9 +186,9 @@ eval "$(minikube docker-env)"
 
 docker build -t ozgenm/gvmd-lite:dev path/to/gvmd-lite
 docker build -t ozgenm/gvmr-lite:dev path/to/gvmr-lite
-docker build -t ozgenm/scanner:dev   path/to/scanner
-docker build -t ozgenm/feed-img:dev  path/to/feed
-docker build -t gsa-lite:prod        path/to/gsa
+docker build -t ozgenm/scanner:dev path/to/scanner
+docker build -t ozgenm/feed-img:dev path/to/feed
+docker build -t gsa-lite:prod path/to/gsa
 ```
 
 Deploy using local images:
@@ -193,6 +211,52 @@ helm upgrade --install gvm charts/gvm-lite-stack -n gvm --create-namespace \
 
 ---
 
+## Container scanning / OCI image targets
+
+Container scanning support is optional and requires a `gvmd-lite` image built with the `container_scanning` build tag.
+
+By default, container scanning is disabled:
+
+```yaml
+gvmdLite:
+  env:
+    ENABLE_CONTAINER_SCANNING: "false"
+```
+
+To enable container scanning, use the feature image and enable the runtime flag:
+
+```bash
+helm upgrade --install gvm charts/gvm-lite-stack -n gvm --create-namespace \
+  --set gvmdLite.image.repository=ozgenm/gvmd-lite-features \
+  --set gvmdLite.image.tag=latest \
+  --set gvmdLite.env.ENABLE_CONTAINER_SCANNING="true"
+```
+
+Or configure it in `values.yaml`:
+
+```yaml
+gvmdLite:
+  image:
+    repository: ozgenm/gvmd-lite-features
+    tag: latest
+  env:
+    ENABLE_CONTAINER_SCANNING: "true"
+```
+
+Both parts are required:
+
+| Requirement                       | Why                                                                         |
+|-----------------------------------|-----------------------------------------------------------------------------|
+| `ozgenm/gvmd-lite-features` image | Contains the backend code compiled with the `container_scanning` build tag. |
+| `ENABLE_CONTAINER_SCANNING=true`  | Enables the feature at runtime.                                             |
+
+Setting `ENABLE_CONTAINER_SCANNING=true` while still using the default `ozgenm/gvmd-lite` image is not enough, because
+the container scanning code is not compiled into that image.
+
+When enabled, OCI image target APIs and related frontend features become available.
+
+---
+
 ## PostgreSQL dependency
 
 This chart includes the **Bitnami PostgreSQL** Helm chart as a dependency:
@@ -205,7 +269,7 @@ dependencies:
     condition: postgresql.enabled
 ```
 
-### Default (enabled)
+### Default enabled
 
 ```yaml
 postgresql:
@@ -213,7 +277,7 @@ postgresql:
   architecture: standalone
   auth:
     username: gvmd
-    password: gvmdpw   # override in production
+    password: gvmdpw # override in production
     database: gvmd-lite-service
   primary:
     persistence:
@@ -223,15 +287,15 @@ postgresql:
 
 This creates:
 
-* a StatefulSet (`gvm-postgresql-0`)
-* a Service (`gvm-postgresql`)
+* a StatefulSet: `gvm-postgresql-0`
+* a Service: `gvm-postgresql`
 * a Secret containing DB credentials
 
 `gvmd-lite` automatically connects to this DB when enabled.
 
 ---
 
-## External PostgreSQL (optional)
+## External PostgreSQL optional
 
 ```bash
 helm upgrade --install gvm charts/gvm-lite-stack -n gvm --create-namespace \
@@ -247,7 +311,7 @@ helm upgrade --install gvm charts/gvm-lite-stack -n gvm --create-namespace \
 
 ---
 
-## Notification integrations (optional)
+## Notification integrations optional
 
 `gvmd-lite` supports outbound notifications via **SMTP**, **Slack**, and **Azure Blob Storage**.
 All integrations are **disabled by default**.
@@ -292,25 +356,41 @@ gvmdLite:
 
 ## Troubleshooting quick commands
 
-* Render with debug:
+Render with debug:
 
-  ```bash
-  helm template gvm charts/gvm-lite-stack -n gvm --debug
-  ```
-* Watch rollout:
+```bash
+helm template gvm charts/gvm-lite-stack -n gvm --debug
+```
 
-  ```bash
-  kubectl -n gvm rollout status deploy/gvmd-lite
-  ```
-* Describe pod issues:
+Watch rollout:
 
-  ```bash
-  kubectl -n gvm describe pod -l app=gvmd-lite
-  ```
+```bash
+kubectl -n gvm rollout status deploy/gvmd-lite
+```
+
+Describe pod issues:
+
+```bash
+kubectl -n gvm describe pod -l app=gvmd-lite
+```
+
+Check API logs:
+
+```bash
+kubectl -n gvm logs deploy/gvmd-lite
+```
+
+Check mounted feed directories:
+
+```bash
+kubectl -n gvm exec deploy/gvmd-lite -- ls -la /var/lib/openvas/plugins
+kubectl -n gvm exec deploy/gvmd-lite -- ls -la /var/lib/notus/advisories
+kubectl -n gvm exec deploy/gvmd-lite -- ls -la /var/lib/gvm
+```
 
 ---
 
-## Persistent Volume Claims (PVCs)
+## Persistent Volume Claims PVCs
 
 The chart creates the following PVCs by default:
 
@@ -324,5 +404,3 @@ The chart creates the following PVCs by default:
 | gvmr-lite – work | Report rendering work dir                | 1Gi  |
 
 PVC sizes can be adjusted in `values.yaml` as needed.
-
----

--- a/charts/gvm-lite-stack/templates/gvmd-lite-deploy.yaml
+++ b/charts/gvm-lite-stack/templates/gvmd-lite-deploy.yaml
@@ -74,6 +74,17 @@ spec:
               value: {{ .Values.gvmdLite.env.LOG_LEVEL | quote }}
             - name: RUNNING_ENV
               value: "k8s"
+            # ---- Audit log cleanup ----
+            - name: AUDIT_LOG_CLEANUP_INTERVAL
+              value: {{ .Values.gvmdLite.env.AUDIT_LOG_CLEANUP_INTERVAL | quote }}
+            - name: AUDIT_LOG_RETENTION_PERIOD
+              value: {{ .Values.gvmdLite.env.AUDIT_LOG_RETENTION_PERIOD | quote }}
+            - name: AUDIT_LOG_CLEANUP_BATCH_SIZE
+              value: {{ .Values.gvmdLite.env.AUDIT_LOG_CLEANUP_BATCH_SIZE | quote }}
+
+            # ---- Optional features ----
+            - name: ENABLE_CONTAINER_SCANNING
+              value: {{ .Values.gvmdLite.env.ENABLE_CONTAINER_SCANNING | quote }}
 
             # ---- Exports ----
             {{- if .Values.gvmrLite.enabled }}
@@ -203,6 +214,8 @@ spec:
           volumeMounts:
             - name: plugins
               mountPath: /var/lib/openvas/plugins
+            - name: notus
+              mountPath: /var/lib/notus
             # exports dir
             {{- if .Values.gvmrLite.enabled }}
             - name: exports
@@ -216,6 +229,9 @@ spec:
         - name: plugins
           persistentVolumeClaim:
             claimName: {{ default .Values.feed.pvc.plugins.name .Values.gvmdLite.pvcPluginsName }}
+        - name: notus
+          persistentVolumeClaim:
+            claimName: {{ .Values.feed.pvc.notus.name }}
         - name: scan-configs
           persistentVolumeClaim:
             claimName: {{ .Values.feed.pvc.gvm.name }}

--- a/charts/gvm-lite-stack/tests/gvmd-lite-deploy_test.yaml
+++ b/charts/gvm-lite-stack/tests/gvmd-lite-deploy_test.yaml
@@ -128,6 +128,57 @@ tests:
           content:
             name: RUNNING_ENV
             value: k8s
+  - it: sets audit log cleanup and optional feature environment variables
+    set:
+      gvmdLite:
+        env:
+          AUDIT_LOG_CLEANUP_INTERVAL: "12h"
+          AUDIT_LOG_RETENTION_PERIOD: "720h"
+          AUDIT_LOG_CLEANUP_BATCH_SIZE: "500"
+          ENABLE_CONTAINER_SCANNING: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_CLEANUP_INTERVAL
+            value: "12h"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_RETENTION_PERIOD
+            value: "720h"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_CLEANUP_BATCH_SIZE
+            value: "500"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_CONTAINER_SCANNING
+            value: "true"
+  - it: renders default audit log cleanup and container scanning environment values
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_CLEANUP_INTERVAL
+            value: "24h"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_RETENTION_PERIOD
+            value: "4320h"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUDIT_LOG_CLEANUP_BATCH_SIZE
+            value: "1000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_CONTAINER_SCANNING
+            value: "false"
   - it: sets scanner host and port using service fqdn
     set:
       clusterDomain: cluster.local

--- a/charts/gvm-lite-stack/values.yaml
+++ b/charts/gvm-lite-stack/values.yaml
@@ -187,6 +187,12 @@ gvmdLite:
     AZURE_STORAGE_ACCOUNT_NAME: ""
     AZURE_CONTAINER_NAME: ""
     AZURE_CONTAINER_ENABLED: "0"
+    # Audit log cleanup
+    AUDIT_LOG_CLEANUP_INTERVAL: "24h"
+    AUDIT_LOG_RETENTION_PERIOD: "4320h"
+    AUDIT_LOG_CLEANUP_BATCH_SIZE: "1000"
+    # Optional features
+    ENABLE_CONTAINER_SCANNING: "false"
 gsaLite:
   replicas: 1
   image:


### PR DESCRIPTION
- Mount the Notus feed PVC into the gvmd-lite deployment
- Add audit log cleanup environment variables to values and deployment
- Add ENABLE_CONTAINER_SCANNING runtime configuration
- Update Helm unit tests for the new environment variables and Notus volume
- Document the feature image requirement for container scanning